### PR TITLE
Changed the lexer for Numeral to accept sequences of digits

### DIFF
--- a/Language/SMTLIB/Lexer.x
+++ b/Language/SMTLIB/Lexer.x
@@ -29,7 +29,7 @@ tokens :-
   \|[$printable \n # \|]*\|          { Symbol  }
   \:$sym+                            { Keyword }
   $digit+\.$digit+                   { Decimal . read }
-  $digit                             { Numeral . read }
+  $digit+                            { Numeral . read }
   \(                                 { const LeftParen  }
   \)                                 { const RightParen }
   \"(([$printable \n # \\]|\\.)*)\"  { String . read }


### PR DESCRIPTION
Hi Tom-

The lexer was generating a token for each digit when parsing multidigit numerals. E.g. "20" tokenized to 'Numeral 2' followed by 'Numeral 0'.

Hopefully this fixes a bug and doesn't just expose my misunderstanding of the lexer; I've never actually used Alex before.

-garrin
