### PR TITLE
improve output efficiency: use Text.PrettyPrint.Leijen instead of String

### DIFF
--- a/Language/SMTLIB.hs
+++ b/Language/SMTLIB.hs
@@ -816,7 +816,7 @@ checkResponses file = do
     return False
 
 clean :: String -> String
-clean = filter (flip notElem " \t\r\n") . unlines . map (takeWhile (/= ';')) . lines
+clean = filter (flip notElem (" \t\r\n" :: String)) . unlines . map (takeWhile (/= ';')) . lines
 
 -- | Recursively searches current directory for *.smt2 files to test the parser.
 checkParser :: IO ()

--- a/Language/SMTLIB/Lexer.x
+++ b/Language/SMTLIB/Lexer.x
@@ -1,15 +1,6 @@
 {
 module Language.SMTLIB.Lexer
-  ( Token (..)
-  , lexSMTLIB
-  , alexScanTokens
-  , alexAndPred
-  , alexPrevCharIs
-  , alexPrevCharIsOneOf
-  , alexRightContext
-  , iUnbox
-  , alexInputPrevChar
-  ) where
+where
 }
 
 %wrapper "basic"

--- a/smt-lib.cabal
+++ b/smt-lib.cabal
@@ -24,10 +24,10 @@ extra-source-files:
 
 library
     build-depends:
-        base       >= 4.0 && < 5.0,
-        directory  >= 1.0         ,
-        array      >= 0.3         ,
-        polyparse  >= 1.4	  ,
+        base      < 5 ,
+        directory ,
+        array     ,
+        polyparse ,
         wl-pprint
 
     exposed-modules:

--- a/smt-lib.cabal
+++ b/smt-lib.cabal
@@ -1,5 +1,5 @@
 name:    smt-lib
-version: 0.0.3
+version: 0.0.3.1
 
 category: Language
 
@@ -25,8 +25,8 @@ extra-source-files:
 library
     build-depends:
         base       >= 4.0 && < 5.0,
-        directory  >= 1.0 && < 1.1,
-        array      >= 0.3 && < 0.4,
+        directory  >= 1.0         ,
+        array      >= 0.3         ,
         polyparse  >= 1.4
 
     exposed-modules:

--- a/smt-lib.cabal
+++ b/smt-lib.cabal
@@ -1,5 +1,5 @@
 name:    smt-lib
-version: 0.0.3.1
+version: 0.0.4
 
 category: Language
 
@@ -27,7 +27,8 @@ library
         base       >= 4.0 && < 5.0,
         directory  >= 1.0         ,
         array      >= 0.3         ,
-        polyparse  >= 1.4
+        polyparse  >= 1.4	  ,
+        wl-pprint
 
     exposed-modules:
         Language.SMTLIB


### PR DESCRIPTION
Hi. 

I needed to output some medium/large constraint systems,
and this function is definitely a performance killer:

group a = "( " ++ intercalate " " a ++ " )"

So I replaced String by Text.PrettyPrint.Leijen.Doc (after I tried with Text.PrettyPrint.HughesPJ which also had problems printing some large documents)

Best, J.W.
